### PR TITLE
Resolve Amazon Lambda Custom Runtime incompatiblities

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -25,6 +25,8 @@ functions:
   helloNative:
     runtime: provided
     handler: handler
+    environment:
+      DISABLE_SIGNAL_HANDLERS: true
     package:
       artifact: target/function.zip
     events:


### PR DESCRIPTION
Without this patch running on aws fails with an internal server error